### PR TITLE
simpler and less error-prone instantiation 

### DIFF
--- a/gqueue-1.3.js
+++ b/gqueue-1.3.js
@@ -12,6 +12,9 @@
  * @constructor
  */
 function GQueue(size, circular) {
+    if (!(this instanceof GQueue)) {
+        return new GQueue(size, circular);
+    }
     this.data = {};
     this.circular = Boolean(circular);
     if (isNaN(this.maxlength = parseInt(size))) {


### PR DESCRIPTION
allow the user to instantiate this pseudo-class simply using "var foo = GQueue(params)", in addition to "var foo = new GQueue(params)"

inspired from jQuery's style, see this post from John Resig for more detailled info: http://ejohn.org/blog/simple-class-instantiation/
